### PR TITLE
feat(db): Implement core data models (Device, Interface)

### DIFF
--- a/crates/db/src/lib.rs
+++ b/crates/db/src/lib.rs
@@ -2,6 +2,9 @@ use sqlx::postgres::{PgPool, PgPoolOptions};
 use nd_core::Settings;
 use std::time::Duration;
 
+mod models;
+pub use models::{Device, DeviceStatus, Interface}; // Be explicit for clarity
+
 // Re-export pool for easier use in other crates
 // pub use sqlx::PgPool; // Removed redundant re-export
 

--- a/crates/db/src/models.rs
+++ b/crates/db/src/models.rs
@@ -1,0 +1,60 @@
+use time::{OffsetDateTime, PrimitiveDateTime};
+use uuid::Uuid;
+use ipnetwork::IpNetwork;
+use sqlx::{FromRow, Type};
+use serde::{Serialize, Deserialize};
+
+// Mirror the device_status enum from the migration
+#[derive(Debug, Clone, PartialEq, Eq, Type, Serialize, Deserialize)]
+#[sqlx(type_name = "device_status", rename_all = "lowercase")]
+pub enum DeviceStatus {
+    Up,
+    Down,
+    Unknown,
+}
+
+// Struct corresponding to the 'devices' table
+#[derive(Debug, Clone, PartialEq, FromRow, Serialize, Deserialize)]
+pub struct Device {
+    pub id: Uuid,
+    pub hostname: Option<String>, // Made Option<> as UNIQUE allows one NULL
+    pub ip_address: IpNetwork, // sqlx maps INET to ipnetwork::IpNetwork
+    pub sys_name: Option<String>,
+    pub sys_descr: Option<String>,
+    pub vendor: Option<String>,
+    pub model: Option<String>,
+    pub os_version: Option<String>,
+    pub serial_number: Option<String>,
+    pub status: Option<DeviceStatus>, // Mapped from device_status enum
+    #[sqlx(default)] // Handle potential NULL in DB or missing field
+    pub last_seen: Option<OffsetDateTime>, // TIMESTAMPTZ maps to OffsetDateTime
+    #[sqlx(default)]
+    pub created_at: OffsetDateTime, 
+    #[sqlx(default)]
+    pub updated_at: OffsetDateTime,
+}
+
+// Struct corresponding to the 'interfaces' table
+#[derive(Debug, Clone, PartialEq, FromRow, Serialize, Deserialize)]
+pub struct Interface {
+    pub id: Uuid,
+    pub device_id: Uuid,
+    pub if_index: i32, // INTEGER maps to i32
+    pub if_name: Option<String>,
+    pub if_alias: Option<String>,
+    pub if_descr: Option<String>,
+    pub if_type: Option<String>,
+    // pub mac_address: Option<[u8; 6]>, // sqlx currently needs feature for MACADDR, handle differently or use String for now
+    pub mac_address: Option<String>, // Using String for MAC for now
+    pub ip_address: Option<IpNetwork>,
+    pub admin_status: Option<String>,
+    pub oper_status: Option<String>,
+    pub speed: Option<i64>, // BIGINT maps to i64
+    pub mtu: Option<i32>,
+    #[sqlx(default)]
+    pub last_changed: Option<OffsetDateTime>,
+    #[sqlx(default)]
+    pub created_at: OffsetDateTime,
+    #[sqlx(default)]
+    pub updated_at: OffsetDateTime,
+} 


### PR DESCRIPTION
Creates db/src/models.rs with structs matching the DB schema (Device, Interface, DeviceStatus). Derives sqlx::FromRow and other necessary traits. Re-exports models from db/src/lib.rs. Relates #5