### PR TITLE
feat(core): Add initial discovery structure placeholders

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -106,6 +106,12 @@ checksum = "89e25b6adfb930f02d1981565a6e5d9c547ac15a96606256d3b59040e5cd4ca3"
 
 [[package]]
 name = "bitflags"
+version = "1.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
+
+[[package]]
+name = "bitflags"
 version = "2.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5c8214115b7bf84099f1309324e63141d4c5d7cc26862f97a0a857dbefe165bd"
@@ -367,7 +373,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "976dd42dc7e85965fe702eb8164f21f450704bdde31faefd6471dba214cb594e"
 dependencies = [
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -892,8 +898,14 @@ name = "nd_core"
 version = "0.1.0"
 dependencies = [
  "config",
+ "oid",
+ "rand",
  "serde",
  "serde_yaml",
+ "snmp_mp",
+ "thiserror 1.0.69",
+ "tokio",
+ "tracing",
 ]
 
 [[package]]
@@ -977,6 +989,12 @@ checksum = "62948e14d923ea95ea2c7c86c71013138b66525b86bdc08d2dcc262bdb497b87"
 dependencies = [
  "memchr",
 ]
+
+[[package]]
+name = "oid"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9c19903c598813dba001b53beeae59bb77ad4892c5c1b9b3500ce4293a0d06c2"
 
 [[package]]
 name = "once_cell"
@@ -1209,7 +1227,7 @@ version = "0.5.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d2f103c6d277498fbceb16e84d317e2a400f160f46904d5f5410848c829511a3"
 dependencies = [
- "bitflags",
+ "bitflags 2.9.0",
 ]
 
 [[package]]
@@ -1263,7 +1281,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b91f7eff05f748767f183df4320a63d6936e9c6107d97c9e6bdd9784f4289c94"
 dependencies = [
  "base64",
- "bitflags",
+ "bitflags 2.9.0",
  "serde",
  "serde_derive",
 ]
@@ -1310,11 +1328,11 @@ version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d97817398dd4bb2e6da002002db259209759911da105da92bec29ccb12cf58bf"
 dependencies = [
- "bitflags",
+ "bitflags 2.9.0",
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -1453,6 +1471,16 @@ name = "smallvec"
 version = "1.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8917285742e9f3e1683f0a9c4e6b57960b7314d0b08d30d1ecd426713ee2eee9"
+
+[[package]]
+name = "snmp_mp"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "40be0a4f051a132f965c76bc269dc6a941665cd01e635327f829cbc8d08a4539"
+dependencies = [
+ "bitflags 1.3.2",
+ "yasna",
+]
 
 [[package]]
 name = "socket2"
@@ -1595,7 +1623,7 @@ checksum = "1ed31390216d20e538e447a7a9b959e06ed9fc51c37b514b46eb758016ecd418"
 dependencies = [
  "atoi",
  "base64",
- "bitflags",
+ "bitflags 2.9.0",
  "byteorder",
  "bytes",
  "crc",
@@ -1639,7 +1667,7 @@ checksum = "7c824eb80b894f926f89a0b9da0c7f435d27cdd35b8c655b114e58223918577e"
 dependencies = [
  "atoi",
  "base64",
- "bitflags",
+ "bitflags 2.9.0",
  "byteorder",
  "crc",
  "dotenvy",
@@ -1763,7 +1791,7 @@ dependencies = [
  "getrandom 0.3.2",
  "once_cell",
  "rustix",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -2351,7 +2379,7 @@ version = "0.39.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6f42320e61fe2cfd34354ecb597f86f413484a798ba44a8ca1165c58d42da6c1"
 dependencies = [
- "bitflags",
+ "bitflags 2.9.0",
 ]
 
 [[package]]
@@ -2376,6 +2404,12 @@ dependencies = [
  "encoding_rs",
  "hashlink",
 ]
+
+[[package]]
+name = "yasna"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0de7bff972b4f2a06c85f6d8454b09df153af7e3a4ec2aac81db1b105b684ddb"
 
 [[package]]
 name = "yoke"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -106,12 +106,6 @@ checksum = "89e25b6adfb930f02d1981565a6e5d9c547ac15a96606256d3b59040e5cd4ca3"
 
 [[package]]
 name = "bitflags"
-version = "1.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
-
-[[package]]
-name = "bitflags"
 version = "2.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5c8214115b7bf84099f1309324e63141d4c5d7cc26862f97a0a857dbefe165bd"
@@ -898,11 +892,9 @@ name = "nd_core"
 version = "0.1.0"
 dependencies = [
  "config",
- "oid",
  "rand",
  "serde",
  "serde_yaml",
- "snmp_mp",
  "thiserror 1.0.69",
  "tokio",
  "tracing",
@@ -989,12 +981,6 @@ checksum = "62948e14d923ea95ea2c7c86c71013138b66525b86bdc08d2dcc262bdb497b87"
 dependencies = [
  "memchr",
 ]
-
-[[package]]
-name = "oid"
-version = "0.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c19903c598813dba001b53beeae59bb77ad4892c5c1b9b3500ce4293a0d06c2"
 
 [[package]]
 name = "once_cell"
@@ -1227,7 +1213,7 @@ version = "0.5.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d2f103c6d277498fbceb16e84d317e2a400f160f46904d5f5410848c829511a3"
 dependencies = [
- "bitflags 2.9.0",
+ "bitflags",
 ]
 
 [[package]]
@@ -1281,7 +1267,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b91f7eff05f748767f183df4320a63d6936e9c6107d97c9e6bdd9784f4289c94"
 dependencies = [
  "base64",
- "bitflags 2.9.0",
+ "bitflags",
  "serde",
  "serde_derive",
 ]
@@ -1328,7 +1314,7 @@ version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d97817398dd4bb2e6da002002db259209759911da105da92bec29ccb12cf58bf"
 dependencies = [
- "bitflags 2.9.0",
+ "bitflags",
  "errno",
  "libc",
  "linux-raw-sys",
@@ -1473,16 +1459,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8917285742e9f3e1683f0a9c4e6b57960b7314d0b08d30d1ecd426713ee2eee9"
 
 [[package]]
-name = "snmp_mp"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "40be0a4f051a132f965c76bc269dc6a941665cd01e635327f829cbc8d08a4539"
-dependencies = [
- "bitflags 1.3.2",
- "yasna",
-]
-
-[[package]]
 name = "socket2"
 version = "0.5.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1623,7 +1599,7 @@ checksum = "1ed31390216d20e538e447a7a9b959e06ed9fc51c37b514b46eb758016ecd418"
 dependencies = [
  "atoi",
  "base64",
- "bitflags 2.9.0",
+ "bitflags",
  "byteorder",
  "bytes",
  "crc",
@@ -1667,7 +1643,7 @@ checksum = "7c824eb80b894f926f89a0b9da0c7f435d27cdd35b8c655b114e58223918577e"
 dependencies = [
  "atoi",
  "base64",
- "bitflags 2.9.0",
+ "bitflags",
  "byteorder",
  "crc",
  "dotenvy",
@@ -2379,7 +2355,7 @@ version = "0.39.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6f42320e61fe2cfd34354ecb597f86f413484a798ba44a8ca1165c58d42da6c1"
 dependencies = [
- "bitflags 2.9.0",
+ "bitflags",
 ]
 
 [[package]]
@@ -2404,12 +2380,6 @@ dependencies = [
  "encoding_rs",
  "hashlink",
 ]
-
-[[package]]
-name = "yasna"
-version = "0.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0de7bff972b4f2a06c85f6d8454b09df153af7e3a4ec2aac81db1b105b684ddb"
 
 [[package]]
 name = "yoke"

--- a/crates/nd_core/Cargo.toml
+++ b/crates/nd_core/Cargo.toml
@@ -7,3 +7,8 @@ edition = "2024"
 config = { version = "0.14", features = ["yaml"] }
 serde = { version = "1.0", features = ["derive"] }
 serde_yaml = "0.9"
+
+thiserror = "1.0"
+rand = "0.8"
+tokio = { version = "1", features = ["rt", "net", "time"] }
+tracing = "0.1"

--- a/crates/nd_core/src/discovery.rs
+++ b/crates/nd_core/src/discovery.rs
@@ -1,0 +1,23 @@
+// Placeholder for discovery logic
+
+pub struct DiscoveryJob {
+    // Define fields later (e.g., target range, credentials)
+}
+
+pub enum DiscoveryResult {
+    // Define variants later (e.g., Success(Device), Failure(Error))
+}
+
+pub struct DiscoveryManager {
+    // Define fields later (e.g., job queue, worker pool)
+}
+
+impl DiscoveryManager {
+    // Placeholder for function to run discovery
+    pub async fn run_discovery(&self, _job: DiscoveryJob) -> Result<(), String> {
+        tracing::info!("Placeholder: Running discovery job...");
+        // Actual logic will go here later, including SNMP calls
+        // For now, just simulate success
+        Ok(())
+    }
+} 

--- a/crates/nd_core/src/lib.rs
+++ b/crates/nd_core/src/lib.rs
@@ -27,3 +27,6 @@ impl Settings {
         s.try_deserialize()
     }
 }
+
+mod discovery;
+pub use discovery::{DiscoveryJob, DiscoveryResult, DiscoveryManager};

--- a/docs/todo.md
+++ b/docs/todo.md
@@ -31,24 +31,24 @@
     *   [ ] *Post-Blocker Task:* Fix struct field mismatches (e.g., hostname, sysname, vendor)
     *   [ ] *Post-Blocker Task:* Resolve type mismatches (e.g., Uuid vs Option<i64>, String vs IpAddr)
     *   [ ] *Post-Blocker Task:* Update all usages of Device/related types in dependent modules (db, api, etc.)
-*   [ ] **SNMP Integration**
+*   [ ] **SNMP Integration** **[PAUSED - Library Issues]**
     *   [ ] Choose and integrate an SNMP library
     *   [ ] Implement basic SNMP v2c Get functionality
-*   [ ] **Device Discovery**
+*   [ ] **Device Discovery** **[Blocked - SNMP]**
     *   [ ] Design discovery protocols/strategy
     *   [ ] Implement basic SNMP discovery logic (fetch sysDescr, sysName, etc.)
     *   [ ] Implement storage of discovered devices into the database
     *   [ ] Implement network scanning (ping sweep / SNMP walk)
     *   [ ] Implement device classification (sysObjectID)
-*   [ ] **Interface Data Collection**
+*   [ ] **Interface Data Collection** **[Blocked - SNMP]**
     *   [ ] Collect interface details via SNMP (IF-MIB)
     *   [ ] Store interface data in the database, linked to devices
-*   [ ] **MAC Address Tracking and Port Mapping**
+*   [ ] **MAC Address Tracking and Port Mapping** **[Blocked - SNMP]**
     *   [ ] Extend DB schema
     *   [ ] Implement MAC address table collection via SNMP (BRIDGE-MIB)
     *   [ ] Implement logic to map MACs to Interfaces/Ports
     *   [ ] Store MAC address history
-*   [ ] **ARP/Neighbor Data Collection**
+*   [ ] **ARP/Neighbor Data Collection** **[Blocked - SNMP]**
     *   [ ] Extend DB schema
     *   [ ] Implement ARP table collection via SNMP (IP-MIB)
     *   [ ] Implement LLDP/CDP neighbor collection via SNMP
@@ -62,7 +62,7 @@
     *   [ ] *Post-Blocker Task:* Correct async/await usage and method signatures if issues arise during implementation.
 
 ## Feature: Device Interaction & Management
-*   [ ] **Switch Port Control**
+*   [ ] **Switch Port Control** **[Blocked - SNMP]**
     *   [ ] Research SNMP SET capabilities/risks
     *   [ ] Implement Port enable/disable (SNMP SET)
     *   [ ] Implement Port speed/duplex config (SNMP SET)


### PR DESCRIPTION
Reverts SNMP integration attempt (Issue #6). Adds discovery module with placeholder structs (Manager, Job, Result) and function. Marks SNMP-dependent tasks as blocked in todo.md. Relates #7