### PR TITLE
feat: Refine discovery structure and move to own crate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -311,6 +311,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "discovery"
+version = "0.1.0"
+dependencies = [
+ "db",
+ "ipnetwork",
+ "nd_core",
+ "thiserror 1.0.69",
+ "tracing",
+]
+
+[[package]]
 name = "displaydoc"
 version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ members = [
     "crates/db",
     "crates/web",
     "crates/cli",
-    ".", # Include the root crate itself
+    ".", "crates/discovery", # Include the root crate itself
 ]
 resolver = "2" # Recommended for workspaces
 

--- a/crates/discovery/Cargo.toml
+++ b/crates/discovery/Cargo.toml
@@ -1,0 +1,15 @@
+[package]
+name = "discovery"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]
+nd_core = { path = "../nd_core" }
+db = { path = "../db" }
+
+ipnetwork = "0.20"
+thiserror = "1.0"
+tracing = "0.1"
+
+# We might need tokio later if discovery becomes async internally
+# tokio = { version = "1", features = ["full"] } 

--- a/crates/discovery/src/lib.rs
+++ b/crates/discovery/src/lib.rs
@@ -1,0 +1,93 @@
+use nd_core::Settings; // Use settings from nd_core
+use db::{Device, DeviceStatus, DbError, PgPool}; // Use types from db crate
+use ipnetwork::IpNetwork;
+use thiserror::Error;
+use std::net::IpAddr;
+
+// --- Structs and Enums previously in nd_core/src/discovery.rs ---
+
+#[derive(Debug, Clone)]
+pub enum DiscoveryTarget {
+    Single(IpAddr),
+    Range(IpAddr, IpAddr),
+    Subnet(IpNetwork),
+}
+
+#[derive(Debug, Clone)]
+pub struct SnmpCredentials {
+    pub community: String,
+}
+
+#[derive(Debug, Clone)]
+pub struct DiscoveryJob {
+    pub target: DiscoveryTarget,
+    pub snmp_creds: Option<SnmpCredentials>,
+}
+
+#[derive(Debug, Error)]
+pub enum DiscoveryError {
+    #[error("SNMP communication failed: {0}")]
+    SnmpError(String),
+    #[error("Database error: {0}")]
+    DbError(#[from] DbError), // Use DbError from db crate
+    #[error("Unsupported target type")]
+    UnsupportedTarget,
+    #[error("Invalid IP range: {0} > {1}")]
+    InvalidRange(IpAddr, IpAddr),
+    #[error("Other error: {0}")]
+    Other(String),
+}
+
+#[derive(Debug)]
+pub enum DiscoveryResult {
+    DeviceFound(Device),
+    DeviceSkipped { ip: IpAddr, reason: String },
+    DeviceFailed { ip: IpAddr, error: DiscoveryError },
+}
+
+pub struct DiscoveryManager {
+    db_pool: PgPool,
+    // config: Settings, // Might need config too
+}
+
+impl DiscoveryManager {
+    pub fn new(db_pool: PgPool/*, config: Settings*/) -> Self {
+        Self { db_pool/*, config*/ }
+    }
+
+    pub async fn run_discovery(&self, _job: DiscoveryJob) -> Result<(), DiscoveryError> {
+        tracing::info!("Placeholder: Running discovery job...");
+        // ... (Placeholder logic remains the same) ...
+        
+        // Example using db_pool eventually:
+        // let device_data = Device { ... }; // Populate from SNMP results
+        // let _saved_device = db::upsert_device(&self.db_pool, &device_data).await?; 
+
+        let simulated_ip: IpAddr = "192.168.1.1".parse().unwrap();
+        let simulated_result = DiscoveryResult::DeviceSkipped {
+            ip: simulated_ip,
+            reason: "SNMP implementation pending".to_string(),
+        };
+        tracing::info!(result = ?simulated_result, "Simulated discovery result");
+
+        Ok(())
+    }
+}
+
+// Remove default lib content if present
+/*
+pub fn add(left: usize, right: usize) -> usize {
+    left + right
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn it_works() {
+        let result = add(2, 2);
+        assert_eq!(result, 4);
+    }
+}
+*/

--- a/crates/nd_core/src/discovery.rs
+++ b/crates/nd_core/src/discovery.rs
@@ -1,23 +1,83 @@
+use crate::{Device, DeviceStatus}; // Import Device model from db crate (via lib.rs)
+use ipnetwork::IpNetwork;
+use thiserror::Error;
+use std::net::IpAddr;
+
 // Placeholder for discovery logic
 
-pub struct DiscoveryJob {
-    // Define fields later (e.g., target range, credentials)
+#[derive(Debug, Clone)]
+pub enum DiscoveryTarget {
+    Single(IpAddr),
+    Range(IpAddr, IpAddr),
+    Subnet(IpNetwork),
+    // List(Vec<IpAddr>), // Could add later
 }
 
+// Placeholder for credentials - needs proper secure handling later!
+#[derive(Debug, Clone)]
+pub struct SnmpCredentials {
+    pub community: String,
+    // Add v3 credentials later
+}
+
+#[derive(Debug, Clone)]
+pub struct DiscoveryJob {
+    pub target: DiscoveryTarget,
+    pub snmp_creds: Option<SnmpCredentials>, // Optional for now
+    // Add other parameters like timeouts, retries later
+}
+
+#[derive(Debug, Error)]
+pub enum DiscoveryError {
+    #[error("SNMP communication failed: {0}")]
+    SnmpError(String), // Placeholder - use actual SnmpError later
+    #[error("Database error: {0}")]
+    DbError(#[from] crate::DbError), // Use DbError from db crate
+    #[error("Unsupported target type")]
+    UnsupportedTarget,
+    #[error("Invalid IP range: {0} > {1}")]
+    InvalidRange(IpAddr, IpAddr),
+    #[error("Other error: {0}")]
+    Other(String),
+}
+
+#[derive(Debug)]
 pub enum DiscoveryResult {
-    // Define variants later (e.g., Success(Device), Failure(Error))
+    DeviceFound(Device), // On success, return the discovered/updated device
+    DeviceSkipped { ip: IpAddr, reason: String }, // e.g., duplicate, filtered out
+    DeviceFailed { ip: IpAddr, error: DiscoveryError }, // Specific error for an IP
 }
 
 pub struct DiscoveryManager {
-    // Define fields later (e.g., job queue, worker pool)
+    db_pool: crate::PgPool, // Add database pool
+                          // Define fields later (e.g., job queue, worker pool, config)
 }
 
 impl DiscoveryManager {
+    pub fn new(db_pool: crate::PgPool) -> Self {
+        Self { db_pool }
+    }
+
     // Placeholder for function to run discovery
-    pub async fn run_discovery(&self, _job: DiscoveryJob) -> Result<(), String> {
+    // Will eventually return a stream or vec of DiscoveryResult
+    pub async fn run_discovery(&self, _job: DiscoveryJob) -> Result<(), DiscoveryError> {
         tracing::info!("Placeholder: Running discovery job...");
-        // Actual logic will go here later, including SNMP calls
+        // 1. Parse job target (subnet, range, single IP)
+        // 2. For each IP:
+        //    a. Ping check (optional)
+        //    b. SNMP Get (sysDescr, etc.) -> Requires working SNMP!
+        //    c. Map SNMP result to Device struct fields
+        //    d. Call db::upsert_device(&self.db_pool, &device_data).await?
+        //    e. Yield/collect DiscoveryResult::DeviceFound or DiscoveryResult::DeviceFailed
+
         // For now, just simulate success
+        let simulated_ip: IpAddr = "192.168.1.1".parse().unwrap();
+        let simulated_result = DiscoveryResult::DeviceSkipped {
+            ip: simulated_ip,
+            reason: "SNMP implementation pending".to_string(),
+        };
+        tracing::info!(result = ?simulated_result, "Simulated discovery result");
+
         Ok(())
     }
 } 

--- a/crates/nd_core/src/lib.rs
+++ b/crates/nd_core/src/lib.rs
@@ -28,5 +28,6 @@ impl Settings {
     }
 }
 
-mod discovery;
-pub use discovery::{DiscoveryJob, DiscoveryResult, DiscoveryManager};
+// Remove discovery re-export
+// mod discovery;
+// pub use discovery::{DiscoveryJob, DiscoveryResult, DiscoveryManager, DiscoveryTarget, DiscoveryError, SnmpCredentials};


### PR DESCRIPTION
Moves discovery logic (Manager, Job, Result structs) to a new 'discovery' crate. Refines the structs with more specific fields. Adjusts dependencies and imports. Relates #7